### PR TITLE
Add Tally integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@giveth/ui-design-system": "^1.2.36",
     "@uniswap/v3-sdk": "^3.6.2-optimism-regenesis",
     "bignumber.js": "^9.0.1",
-    "bnc-onboard": "^1.34.1",
+    "bnc-onboard": "^1.36.0",
     "ethers": "^5.4.5",
     "next": "^12.0.7",
     "react": "^17.0.2",

--- a/src/context/onboard.context.tsx
+++ b/src/context/onboard.context.tsx
@@ -93,9 +93,8 @@ export const OnboardProvider: FC<Props> = ({ children }) => {
 								config.XDAI_CONFIG.nodeUrl,
 						},
 					},
-					{
-						walletName: 'torus',
-					},
+					{ walletName: 'torus'},
+					{ walletName: 'tally'},
 				],
 			},
 			walletCheck: [


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.
